### PR TITLE
Add prettier (and reformat code)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+/bin
+/build
+/coverage
+/flow-typed
+/sharness

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "bracketSpacing": false,
+  "arrowParens": "always"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "gh-avatar": "^2.0.0",
     "sharp": "^0.22.1"
   },
-  "devDependencies": {},
-  "scripts": {},
+  "devDependencies": {
+    "prettier": "^1.18.2"
+  },
+  "scripts": {
+    "prettify": "prettier --write '**/*.js'",
+    "check-pretty": "prettier --list-different '**/*.js'"
+  },
   "license": "MIT + Apache-2"
 }

--- a/src/avatars.js
+++ b/src/avatars.js
@@ -1,17 +1,16 @@
-'use strict';
+"use strict";
 
-import getAvatarURL from 'gh-avatar'
-import axios from 'axios'
-import sharp from 'sharp'
+import getAvatarURL from "gh-avatar";
+import axios from "axios";
+import sharp from "sharp";
 
 export const fetchEmbedableAvatar = async (username, token, {avatarSize}) => {
-	const url = await getAvatarURL(username);
-	const httpResult = await axios.get(url, {responseType: 'arraybuffer'});
-	const resizedImage = await
-		sharp(Buffer.from(httpResult.data))
-		.resize(avatarSize, avatarSize)
-		.png()
-		.toBuffer();
+  const url = await getAvatarURL(username);
+  const httpResult = await axios.get(url, {responseType: "arraybuffer"});
+  const resizedImage = await sharp(Buffer.from(httpResult.data))
+    .resize(avatarSize, avatarSize)
+    .png()
+    .toBuffer();
 
-	return `data:image/png;base64,${resizedImage.toString('base64')}`;
+  return `data:image/png;base64,${resizedImage.toString("base64")}`;
 };

--- a/src/scores.js
+++ b/src/scores.js
@@ -1,19 +1,24 @@
-'use strict';
+"use strict";
 
-const EXPECTED_SCORE_VERSION = '0.1.0';
-const EXPECTED_SCORE_TYPE = 'sourcecred/cli/scores';
+const EXPECTED_SCORE_VERSION = "0.1.0";
+const EXPECTED_SCORE_TYPE = "sourcecred/cli/scores";
 
-const validateScoreFormat = plainObject => {
-	const [versionHeader, scoreData] = plainObject;
+const validateScoreFormat = (plainObject) => {
+  const [versionHeader, scoreData] = plainObject;
 
-	if(versionHeader.version !== EXPECTED_SCORE_VERSION || versionHeader.type !== EXPECTED_SCORE_TYPE) {
-		throw new Error(`Expecting type "${EXPECTED_SCORE_TYPE}" and version "${EXPECTED_SCORE_VERSION}" in the header of our scores file.`);
-	}
+  if (
+    versionHeader.version !== EXPECTED_SCORE_VERSION ||
+    versionHeader.type !== EXPECTED_SCORE_TYPE
+  ) {
+    throw new Error(
+      `Expecting type "${EXPECTED_SCORE_TYPE}" and version "${EXPECTED_SCORE_VERSION}" in the header of our scores file.`
+    );
+  }
 
-	return scoreData;
+  return scoreData;
 };
 
-export const fromJSONString = jsonString => {
-	const plainObject = JSON.parse(jsonString);
-	return validateScoreFormat(plainObject);
+export const fromJSONString = (jsonString) => {
+  const plainObject = JSON.parse(jsonString);
+  return validateScoreFormat(plainObject);
 };

--- a/src/svg.js
+++ b/src/svg.js
@@ -1,37 +1,46 @@
-'use strict';
+"use strict";
 
-import {fetchEmbedableAvatar} from './avatars'
+import {fetchEmbedableAvatar} from "./avatars";
 
-export const createContributorWall = async (users, token, {minCred, maxUsers, usersPerRow, avatarSize, margin}) => {
-	const selectedUsers = users
-		.slice(0, maxUsers)
-		.filter(user => user.totalCred >= minCred);
+export const createContributorWall = async (
+  users,
+  token,
+  {minCred, maxUsers, usersPerRow, avatarSize, margin}
+) => {
+  const selectedUsers = users
+    .slice(0, maxUsers)
+    .filter((user) => user.totalCred >= minCred);
 
-	const usersWithImages = await Promise.all(
-		selectedUsers.map(user =>
-			fetchEmbedableAvatar(user.id, token, {avatarSize})
-			.then(avatarSlug => ({
-				id: user.id,
-				totalCred: user.totalCred,
-				avatarSlug
-			}))
-		)
-	);
+  const usersWithImages = await Promise.all(
+    selectedUsers.map((user) =>
+      fetchEmbedableAvatar(user.id, token, {avatarSize}).then((avatarSlug) => ({
+        id: user.id,
+        totalCred: user.totalCred,
+        avatarSlug,
+      }))
+    )
+  );
 
-	const images = usersWithImages
-		.map((user, i) => ({
-			...user,
-			posX: (i % usersPerRow) * (avatarSize + margin),
-			posY: Math.floor(i / usersPerRow) * (avatarSize + margin)
-		}))
-		.map(user => 
-			`<a href="https://github.com/${user.id}" class="link" target="_blank" id="${user.id}">` +
-			`<image x="${user.posX}" y="${user.posY}" width="${avatarSize}" height="${avatarSize}" xlink:href="${user.avatarSlug}"/>` +
-			`</a>`
-		);
+  const images = usersWithImages
+    .map((user, i) => ({
+      ...user,
+      posX: (i % usersPerRow) * (avatarSize + margin),
+      posY: Math.floor(i / usersPerRow) * (avatarSize + margin),
+    }))
+    .map(
+      (user) =>
+        `<a href="https://github.com/${user.id}" class="link" target="_blank" id="${user.id}">` +
+        `<image x="${user.posX}" y="${user.posY}" width="${avatarSize}" height="${avatarSize}" xlink:href="${user.avatarSlug}"/>` +
+        `</a>`
+    );
 
-	return `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${(avatarSize + margin) * usersPerRow - margin}" height="${Math.ceil(images.length / usersPerRow) * (avatarSize + margin) - margin}">
+  return `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${(avatarSize +
+    margin) *
+    usersPerRow -
+    margin}" height="${Math.ceil(images.length / usersPerRow) *
+    (avatarSize + margin) -
+    margin}">
 		<style>.link { cursor: pointer; }</style>
-		${images.join('\n')}
-	</svg>`
+		${images.join("\n")}
+	</svg>`;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,6 +486,11 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
This commit adds a dependency on prettier, and sets up scripts in
`package.json` to use prettify to format all the files.

I then re-formatted all the files using `yarn prettify`.

Test plan: `yarn prettify` produces no changes. `yarn check-pretty`
exits without issue.

Note: I deliberately copied over the full `.prettierignore` from sourcecred (including ignoring folders that don't yet exist here) because I intend to have a similar directory structure, so anything being ignored in sourcecred should probably also get ignored here.