### PR TITLE
Add example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ commands:
     steps:
       # This ensures we can approach github over SSH.
       - run: |
-        mkdir -p ~/.ssh;
-        ssh-keyscan -H github.com >> ~/.ssh/known_hosts;
+          mkdir -p ~/.ssh;
+          ssh-keyscan -H github.com >> ~/.ssh/known_hosts;
       # Include a bot account SSH key if you're using the git plugin.
       # echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa;
       - run: ./example/rebuild-widgets.sh
@@ -41,18 +41,18 @@ commands:
     description: Commit and push ./example/site to the gh-pages branch
     steps:
       - run: |
-        mkdir -p ~/.ssh;
-        ssh-keyscan -H github.com >> ~/.ssh/known_hosts;
-        echo "$SSH_DEPLOY_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa;
+          mkdir -p ~/.ssh;
+          ssh-keyscan -H github.com >> ~/.ssh/known_hosts;
+          echo "$SSH_DEPLOY_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa;
       - run: |
-        cd ~/repo/example/site;
-        git init;
-        git config user.email "bot@sourcecred.io";
-        git config user.name "Deployment Bot";
-        git checkout -b gh-pages;
-        git add --all;
-        git commit -m "Publishing to gh-pages `date`";
-        git push --dry-run -f git@github.com:sourcecred/widgets.git gh-pages;
+          cd ~/repo/example/site;
+          git init;
+          git config user.email "bot@sourcecred.io";
+          git config user.name "Deployment Bot";
+          git checkout -b gh-pages;
+          git add --all;
+          git commit -m "Publishing to gh-pages `date`";
+          git push --dry-run -f git@github.com:sourcecred/widgets.git gh-pages;
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,34 @@ commands:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+  rebuild_example_site:
+    # Requires the SOURCECRED_GITHUB_TOKEN secret env var.
+    description: Generate a new version of the example site
+    steps:
+      # This ensures we can approach github over SSH.
+      - run: |
+        mkdir -p ~/.ssh;
+        ssh-keyscan -H github.com >> ~/.ssh/known_hosts;
+      # Include a bot account SSH key if you're using the git plugin.
+      # echo "$SSH_BOT_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa;
+      - run: ./example/rebuild-widgets.sh
+  deploy_example_site:
+    # Requires the SSH_DEPLOY_KEY secret env var.
+    description: Commit and push ./example/site to the gh-pages branch
+    steps:
+      - run: |
+        mkdir -p ~/.ssh;
+        ssh-keyscan -H github.com >> ~/.ssh/known_hosts;
+        echo "$SSH_DEPLOY_KEY" > ~/.ssh/id_rsa && chmod 0600 ~/.ssh/id_rsa;
+      - run: |
+        cd ~/repo/example/site;
+        git init;
+        git config user.email "bot@sourcecred.io";
+        git config user.name "Deployment Bot";
+        git checkout -b gh-pages;
+        git add --all;
+        git commit -m "Publishing to gh-pages `date`";
+        git push --dry-run -f git@github.com:sourcecred/widgets.git gh-pages;
 
 jobs:
   test:
@@ -33,9 +61,26 @@ jobs:
       - checkout
       - set_up_node_modules
       - run: yarn test
+  update_example_site:
+    executor: node
+    steps:
+      - checkout
+      - run: git submodule update --recursive --init
+      - rebuild_example_site
+      - deploy_example_site
 
 workflows:
   version: 2
   commit:
     jobs:
       - test
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 23 * * *"  # 23:00 UTC
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - update_example_site

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "example/sourcecred"]
+	path = example/sourcecred
+	url = https://github.com/sourcecred/sourcecred.git

--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ yarn
 # 3. Generate a contributor wall SVG.
 ./bin/contributor-wall-svg.js < scores.json > contributors.svg
 ```
+
+## Contributors
+
+Many thanks to the people who have contributed to this repository.
+
+![sourcecred/widgets contributors](http://widgets.sourcecred.io/sourcecred-widgets-contributors.svg)
+
+_Based on all-time SourceCred scores._

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,2 @@
+/site
+/sourcecred_data

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,26 @@
+# SourceCred Widgets example
+
+## Usage
+
+```sh
+export SOURCECRED_GITHUB_TOKEN=YOUR_GITHUB_TOKEN
+./rebuild-widgets.sh
+```
+
+Then commit the output `site` directory to GitHub pages.
+
+## Tweaking
+
+The `repositories.txt` file contains a line-separated list of repositories to generate the widgets for.
+
+If you'd like to add a `CNAME` file to the output, you can create it in the `static` folder, as this will be copied.
+
+Changing parameters of the widgets invocation should be done in the `rebuild-widgets.sh` script, or by exporting the variables beforehand.
+For example:
+
+```sh
+export SOURCECRED_GITHUB_TOKEN=YOUR_GITHUB_TOKEN
+export SVG_MIN_CRED=4.5
+export SVG_MAX_USERS=100
+./rebuild-widgets.sh
+```

--- a/example/manual-deploy.sh
+++ b/example/manual-deploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "${toplevel}/example/site"
+
+git init
+git checkout -b gh-pages
+git add --all
+git commit -m "Publishing to gh-pages `date`"
+git push -f git@github.com:sourcecred/widgets.git gh-pages

--- a/example/rebuild-widgets.sh
+++ b/example/rebuild-widgets.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+toplevel="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+example_dir="${toplevel}/example"
+cd "${example_dir}"
+
+die() {
+    printf >&2 'fatal: %s\n' "$@"
+    exit 1
+}
+
+# Check our dependencies.
+[ -z "$(which node)" ] && die "Node must be installed and available in \$PATH"
+[ -z "$(which yarn)" ] && die "Yarn must be installed and available in \$PATH"
+
+# Make sure we have a token.
+[ -z "${SOURCECRED_GITHUB_TOKEN}" ] && die "No SOURCECRED_GITHUB_TOKEN has been set."
+
+# Find our repository list.
+[ ! -e "repositories.txt" ] && die "A repositories.txt file is expected in the repository root."
+REPOS="$(cat repositories.txt)"
+
+# Rebuild sourcecred dependencies.
+echo "Building SourceCred binaries."
+cd "${example_dir}/sourcecred"
+SOURCECRED_BIN="${example_dir}/sourcecred/bin"
+yarn
+yarn -s backend --output-path "${SOURCECRED_BIN}"
+
+# Reload repository data.
+echo "Loading repository data."
+SOURCECRED_DIRECTORY="${example_dir}/sourcecred_data"
+for repo in $REPOS; do
+	SOURCECRED_DIRECTORY="${SOURCECRED_DIRECTORY}" node "${SOURCECRED_BIN}/sourcecred.js" load "${repo}" $WEIGHTS_OPT
+done
+
+# Copying static assets.
+echo "Copying static assets"
+target="${example_dir}/site"
+[ -d "${target}" ] && rm -rf "${target}"
+mkdir -p "${target}"
+cp -r "${example_dir}/static/"* "${target}"
+
+# Generate widgets.
+echo "Generating widgets"
+cd "${toplevel}"
+yarn
+for repo in $REPOS; do
+	echo "Generating ${repo//\//-}-contributors.svg"
+	SOURCECRED_DIRECTORY="${SOURCECRED_DIRECTORY}" node "${SOURCECRED_BIN}/sourcecred.js" scores "${repo}" | \
+		./bin/contributor-wall-svg.js > "${target}/${repo//\//-}-contributors.svg"
+done

--- a/example/repositories.txt
+++ b/example/repositories.txt
@@ -1,0 +1,1 @@
+sourcecred/widgets

--- a/example/static/CNAME
+++ b/example/static/CNAME
@@ -1,0 +1,1 @@
+widgets.sourcecred.io

--- a/example/static/index.html
+++ b/example/static/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      max-width: 980px;
+      border: 1px solid #ddd;
+      outline: 1300px solid #fff;
+      margin: 16px auto;
+    }
+    .markdown-body {
+      padding: 45px;
+      font-family: sans-serif;
+      -ms-text-size-adjust: 100%;
+      -webkit-text-size-adjust: 100%;
+      color: #333333;
+      overflow: hidden;
+      font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      word-wrap: break-word;
+    }
+    .markdown-body > :first-child {
+      margin-top: 0 !important;
+    }
+    h1 {
+      padding-bottom: 0.3em;
+      font-size: 2.25em;
+      line-height: 1.2;
+      border-bottom: 1px solid #eee;
+    }
+    h3 {
+      font-size: 1.5em;
+      line-height: 1.43;
+    }
+  </style>
+  <title>SourceCred Widgets</title>
+</head>
+<body>
+<article class="markdown-body">
+  <h1 id="sourcecred-widgets">SourceCred Widgets</a></h1>
+  <p>A Node.js based set of tools to interpret SourceCred scores and generate widgets.<br>
+  For example to use in README&rsquo;s or as webpage static assets.</p>
+  <p>More information on GitHub: <a href="https://github.com/sourcecred/widgets">https://github.com/sourcecred/widgets</a></p>
+  <h3 id="contributors">Contributors</a></h3>
+  <p>Many thanks to the people who have contributed to this repository.</p>
+  <p><img alt="sourcecred/widgets contributors" src="sourcecred-widgets-contributors.svg" /></p>
+</article>
+</body>
+</html>

--- a/example/static/index.html
+++ b/example/static/index.html
@@ -41,7 +41,9 @@
 <body>
 <article class="markdown-body">
   <h1 id="sourcecred-widgets">SourceCred Widgets</a></h1>
-  <p>A Node.js based set of tools to interpret SourceCred scores and generate widgets.<br>
+  <p>A Node.js based set of tools to interpret
+  <a href="https://sourcecred.io">SourceCred</a>
+  scores and generate widgets.<br>
   For example to use in README&rsquo;s or as webpage static assets.</p>
   <p>More information on GitHub: <a href="https://github.com/sourcecred/widgets">https://github.com/sourcecred/widgets</a></p>
   <h3 id="contributors">Contributors</a></h3>


### PR DESCRIPTION
Here's an example to run updates of the sourcecred/widgets repository. Fixes #7 

I've not been able to test the CircleCI port of this script yet, but the manual steps of this example do work and were used for the current gh-pages branch.

As an alternative to secrets, [`add_ssh_keys`](https://circleci.com/docs/2.0/configuration-reference/#add_ssh_keys) may be used. But the keyscan step and github token will still be required.