### PR TITLE
Pushes the Docker tags we're creating manually 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,8 @@ workflows:
                    echo "Commit for Docker tag is ${DOCKER_TAG}"
                    docker tag sourcecred/widgets:latest sourcecred/widgets:${DOCKER_TAG}
                    docker tag sourcecred/widgets:latest sourcecred/widgets:dev
+                   docker push sourcecred/widgets:${DOCKER_TAG}
+                   docker push sourcecred/widgets:dev
 
   nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,7 @@ workflows:
                    echo "Commit for Docker tag is ${DOCKER_TAG}"
                    docker tag sourcecred/widgets:latest sourcecred/widgets:${DOCKER_TAG}
                    docker tag sourcecred/widgets:latest sourcecred/widgets:dev
-                   docker push sourcecred/widgets:${DOCKER_TAG}
-                   docker push sourcecred/widgets:dev
+                   docker push sourcecred/widgets
 
   nightly:
     jobs:


### PR DESCRIPTION
We didn't explicitly push the new tags we created in our hook.
Meaning only `latest` gets updated as this is part of the orb's command.

See also https://github.com/sourcecred/widgets/pull/22#issuecomment-525861256 and https://github.com/sourcecred/sourcecred/pull/1320#pullrequestreview-281009632