### PR TITLE
Skip CI on gh-pages push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
           git config user.name "Deployment Bot";
           git checkout -b gh-pages;
           git add --all;
-          git commit -m "Publishing to gh-pages `date`";
+          git commit -m "Publishing to gh-pages `date`" -m "[ci skip]";
           git push -f git@github.com:sourcecred/widgets.git gh-pages;
   pull_cache_from_images:
     description: Pulls docker images usable for our cache.


### PR DESCRIPTION
This should stop causing errors where Circle CI doesn't have it's expected config file for gh-pages.

Based on https://discuss.circleci.com/t/cant-ignore-the-gh-pages-branch/2002

Tested by locally running the modified commit file to see it add the skip flag.
But, will have to see how Circle responds.